### PR TITLE
DOCS: Create Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Token Engineering Commons
+    url: https://tecommons.org/
+    about: Learn about the TEC

--- a/.github/ISSUE_TEMPLATE/contributors.md
+++ b/.github/ISSUE_TEMPLATE/contributors.md
@@ -1,0 +1,29 @@
+---
+name: For Contributors
+about: 'Template for issues, specifically open to contributions from the community'
+title: ''
+labels: 'For Contributors'
+assignees: ''
+
+---
+
+Welcome! This is an issue for any contributor to pick up so, if you want to contribute to the TEC mission, then you’ve come to the right place. 
+
+If you’re not already on our Discord server, now is the best time to join us there: https://discord.gg/V9gQ2mRU9u
+
+The Community Steward that will support and review this work is : @ 
+
+## 👇🏽  What is this issue about?
+<!-- Give as much detail as you can -->
+
+
+## ✨  What does success look like? (i.e., the criteria to meet to call this issue done)
+1.
+2.
+3.
+
+
+##  💭 Who should be part of Advice Process on this issue (i.e., those in the community who should be consulted about this issue because they will have valuable input):
+@
+
+## 🔗  The links and docs related to this issue:

--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,6 +1,6 @@
 ---
 name: Default
-about: 'Template for default issues '
+about: 'Template for default issues'
 title: ''
 labels: ''
 assignees: ''
@@ -10,18 +10,18 @@ assignees: ''
 ## 👇🏽  What is this issue about? Give as much detail as you can. 
 
 
-## ✨  What does success look like? 
+## ✨  What does success look like? (i.e., the criteria to meet to call this issue done)
 1.
 2.
 3.
 
 
-##🧍🏻‍♀️🧍🏻‍♂️ Who should be part of the Advice Process?
+##🧍🏻‍♀️🧍🏻‍♂️ Who should be part of the Advice Process? (People who should be consulted about this issue. Those who will have valuable input.)
 @
 
 
 ## 🔗  Are there links or docs related to this issue?
 
 
-## 👀  Who are the reviewers?
+## 👀  Who should be in the loop about this issue?
 @


### PR DESCRIPTION
### Relevant Issue
closes #710 

### Description
This PR adds an extra template - [`For Contributors`](https://github.com/Vyvy-vi/coordination/blob/docs/issue-templates/.github/ISSUE_TEMPLATE/contributors.md), that gets the label and also renders a neat UI to choose the issue type.

### Screenshot
![Screenshot 2021-05-26 at 11 29 01 PM](https://user-images.githubusercontent.com/62864373/119719893-f75e9c80-be86-11eb-95fc-030b6a335fd6.png)
